### PR TITLE
Add import module action to restore database

### DIFF
--- a/imageroot/actions/import-module/40restoreDB
+++ b/imageroot/actions/import-module/40restoreDB
@@ -1,0 +1,1 @@
+../restore-module/40restoreDB

--- a/imageroot/actions/restore-module/40restoreDB
+++ b/imageroot/actions/restore-module/40restoreDB
@@ -18,7 +18,7 @@ mysql --version
 # The script is sourced, override entrypoint args and exit:
 set -- true
 docker_temp_server_stop
-exit 1
+exit 0
 EOS
 
 # once we exit we remove initdb.d

--- a/imageroot/actions/restore-module/40restoreDB
+++ b/imageroot/actions/restore-module/40restoreDB
@@ -36,6 +36,6 @@ podman run \
   --env MARIADB_ROOT_PASSWORD=Nethesis,1234 \
   --env MARIADB_DATABASE=sogo \
   --env MARIADB_USER=sogo \
-  --env MARIADB_PASSWORD=sogo \
+  --env MARIADB_PASSWORD=Nethesis,1234 \
   --replace --name=restore_db \
   ${MARIADB_IMAGE}


### PR DESCRIPTION
This pull request adds a new import module action called "40restoreDB" to the imageroot/actions/import-module directory. The action restores the database using the "40restoreDB" module from the imageroot/restore-module directory.

https://github.com/NethServer/dev/issues/6804