### PR TITLE
Replace configure module with restore module

### DIFF
--- a/imageroot/actions/clone-module/20configure
+++ b/imageroot/actions/clone-module/20configure
@@ -1,1 +1,0 @@
-../configure-module/20configure

--- a/imageroot/actions/clone-module/50call-configure-module
+++ b/imageroot/actions/clone-module/50call-configure-module
@@ -1,0 +1,1 @@
+../restore-module/50call-configure-module


### PR DESCRIPTION
This pull request replaces the configure module with the restore module in the imageroot/actions/clone-module directory. The configure module has been deleted and the restore module has been added. This change improves the functionality and efficiency of the code.

We need to link to the restore script and not to the configure-module script that expects a json stdin