### PR TITLE
Fix condition to check if 'addusers' key exists in kd dictionary

### DIFF
--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -39,7 +39,7 @@ for key in agent.list_service_providers(rdb,'imap','tcp'):
     mail = key['module_id']
     get_retval = agent.tasks.run(f"module/{mail}",'list-domains')
     for kd in get_retval['output']:
-        if 'addusers' in kd and kd.get('addusers') == True:
+        if kd.get('addusers') == True:
             obj = {
                 "name": key['module_id'],
                 "label": f"{kd['domain']} ({key['mail_hostname']})",

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -39,7 +39,7 @@ for key in agent.list_service_providers(rdb,'imap','tcp'):
     mail = key['module_id']
     get_retval = agent.tasks.run(f"module/{mail}",'list-domains')
     for kd in get_retval['output']:
-        if kd['addusers']:
+        if 'addusers' in kd and kd.get('addusers') == True:
             obj = {
                 "name": key['module_id'],
                 "label": f"{kd['domain']} ({key['mail_hostname']})",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -49,7 +49,8 @@
     "workers_count_placeholder": "Default value is 3",
     "auxiliary_account": "Auxiliary email account",
     "auxiliary_account_tips": "Users can add auxiliary email accounts to use with SOGo",
-    "no_available_mail_domain_check_users": "No available mail domain, please check if users are added from user domain"
+    "no_available_mail_domain_check_users": "Make sure the mail domain you intend to use has \"Add user addresses from user domain\" checkbox enabled",
+    "mail_module_misconfigured": "No mail domain available"
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -48,7 +48,8 @@
     "workers_count_tips": "Number of workers to use for SOGo",
     "workers_count_placeholder": "Default value is 3",
     "auxiliary_account": "Auxiliary email account",
-    "auxiliary_account_tips": "Users can add auxiliary email accounts to use with SOGo"
+    "auxiliary_account_tips": "Users can add auxiliary email accounts to use with SOGo",
+    "no_available_mail_domain_check_users": "No available mail domain, please check if users are added from user domain"
   },
   "about": {
     "title": "About"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -365,6 +365,16 @@ export default {
           this.mail_server = "";
         }
         this.ldap_domain = config.ldap_domain;
+        // if mail_server_URL is empty, set default value
+        if (this.mail_server_URL.length === 0) {
+          this.mail_server_URL.push({
+            label: this.$t("settings.no_available_mail_domain_check_users"),
+            value: "",
+            name: ""
+          });
+          // we want to avoid to save the form, there is no users set in the mail domain
+          this.mail_server = "";
+        }
       });
 
       this.mail_server_URL = config.mail_server_URL;

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -58,6 +58,16 @@
                 $t("settings.enabled")
               }}</template>
             </NsToggle>
+            <cv-row v-if="mail_server_URL.length === 0">
+              <cv-column>
+                <NsInlineNotification
+                  kind="warning"
+                  :title="$t('settings.mail_module_misconfigured')"
+                  :description="$t('settings.no_available_mail_domain_check_users')"
+                  :showCloseButton="false"
+                />
+              </cv-column>
+            </cv-row>
             <NsComboBox
               v-model.trim="mail_server"
               :autoFilter="true"
@@ -367,11 +377,6 @@ export default {
         this.ldap_domain = config.ldap_domain;
         // if mail_server_URL is empty, set default value
         if (this.mail_server_URL.length === 0) {
-          this.mail_server_URL.push({
-            label: this.$t("settings.no_available_mail_domain_check_users"),
-            value: "",
-            name: ""
-          });
           // we want to avoid to save the form, there is no users set in the mail domain
           this.mail_server = "";
         }


### PR DESCRIPTION
This pull request fixes the condition in the code that checks if the 'addusers' key exists in the 'kd' dictionary. 

This fix ensures that the condition correctly checks for the existence of the 'addusers' key in the dictionary.

However we need to explain to the sysadmin why the NSCOMBOBOW is empty, this is because there is no mail domain set in the mail server or no users are taken from the user domain (from ldap)

![image](https://github.com/NethServer/ns8-sogo/assets/3164851/c66feebb-3016-480e-81f7-81e316a33137)
https://github.com/NethServer/dev/issues/6837