### PR TITLE
Add hostname validation for 'host' field in validate-input.json

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -35,7 +35,9 @@
             "type": "boolean"
         },
         "host": {
-            "type": "string"
+            "type": "string",
+            "format": "hostname",
+            "pattern": "\\."
         },
         "workers_count": {
             "type": "string"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -50,7 +50,9 @@
     "auxiliary_account": "Auxiliary email account",
     "auxiliary_account_tips": "Users can add auxiliary email accounts to use with SOGo",
     "no_available_mail_domain_check_users": "Make sure the mail domain you intend to use has \"Add user addresses from user domain\" checkbox enabled",
-    "mail_module_misconfigured": "No mail domain available"
+    "mail_module_misconfigured": "No mail domain available",
+    "host_pattern": "Must be a valid fully qualified domain name",
+    "host_format": "Must be a valid fully qualified domain name"
   },
   "about": {
     "title": "About"


### PR DESCRIPTION
This pull request adds hostname validation for the 'host' field in the validate-input.json file. It also includes validation messages for the host pattern and format in the translation.json file. This ensures that the 'host' field accepts only valid fully qualified domain names.

https://github.com/NethServer/dev/issues/6853