### PR TITLE
feat(activesync): increase the client timeout to 3600 in apache vhost

### DIFF
--- a/imageroot/templates/SOGo.conf
+++ b/imageroot/templates/SOGo.conf
@@ -79,7 +79,7 @@ RedirectMatch ^/$ https://{{domain}}/SOGo
 #
 ProxyPass /Microsoft-Server-ActiveSync \
  http://127.0.0.1:20000/SOGo/Microsoft-Server-ActiveSync \
- retry=60 connectiontimeout=5 timeout=360
+ retry=60 connectiontimeout=5 timeout=3600
 {% endif %}
 
 ProxyPass /SOGo http://127.0.0.1:20000/SOGo retry=0 nocanon


### PR DESCRIPTION
following this [link](https://community.nethserver.org/t/sogo-gives-a-lot-of-pid-timeouts/24914/7?u=stephdl) we saw that a timeout to 360 minutes is probably not enough. We previously[ used 3600 with NS7 ](https://github.com/NethServer/nethserver-sogo/blob/edf8e7bdf33422e6adaa86e7b8a5bf385ebdc7e4/root/etc/e-smith/templates/etc/httpd/conf.d/zzz_SOGo.conf/10base#L73)