### PR TITLE
Update Sogo version to 5.12.1 in build images script

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -15,7 +15,7 @@ images=()
 repobase="${REPOBASE:-ghcr.io/nethserver}"
 # Configure the image name
 reponame="sogo"
-sogo_version="5.12.0"
+sogo_version="5.12.1"
 
 # Create a new empty container image
 container=$(buildah from scratch)


### PR DESCRIPTION
Upgrade the Sogo version in the build-images script to ensure the latest features and fixes are included.

NethServer/dev#7468