### PR TITLE
Add SOGo theme customization instructions and fix service configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ vim templates/cron.conf.local
 systemctl restart --user sogo
 ```
 
+## Customize SOGo theme
+
+You can customize the SOGo theme by dropping files in folders `./state{js,css,img}` and by restarting sogo
+
+`runagent -m sogo1`
+
+wget your files
+
+```
+wget -O js/custom.js https://example.com/some-script.js
+wget -O img/custom.svg https://example.com/some-image.svg
+wget -O css/custom.css https://example.com/class.css
+systemctl restart --user sogo
+```
+
+The files are included in the backup of the module
 
 ## Backup database
 

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -6,3 +6,6 @@
 state/sogo.sql
 state/backups
 state/templates
+state/css
+state/img
+state/js

--- a/imageroot/systemd/user/sogo-app.service
+++ b/imageroot/systemd/user/sogo-app.service
@@ -16,7 +16,7 @@ EnvironmentFile=-%S/state/discovery_ldap.env
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70
-ExecStartPre=/usr/bin/bash -c "/bin/mkdir -p {config,backups,templates}"
+ExecStartPre=/usr/bin/bash -c "/bin/mkdir -p {config,backups,templates,css,img,js}"
 ExecStartPre=/bin/rm -f %t/sogo-app.pid %t/sogo-app.ctr-id
 ExecStartPre=/usr/local/bin/runagent discover-service
 ExecStartPre=/usr/local/bin/runagent discover-ldap
@@ -31,6 +31,9 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/sogo-app.pid \
     --volume ./config/sieve.creds:/etc/sogo/sieve.creds:Z \
     --volume ./config/SOGo.conf:/etc/httpd/conf/extra/SOGo.conf:Z \
     --volume ./backups:/etc/sogo/backups:Z \
+    --volume ./css:/usr/lib/GNUstep/SOGo/WebServerResources/css:Z \
+    --volume ./img:/usr/lib/GNUstep/SOGo/WebServerResources/img:Z \
+    --volume ./js:/usr/lib/GNUstep/SOGo/WebServerResources/js:Z \
     ${SOGO_SERVER_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/sogo-app.ctr-id -t 10
 ExecReload=/usr/bin/podman kill -s HUP sogo-app


### PR DESCRIPTION
Introduce a section in the README for customizing the SOGo theme. Update the state-include configuration to include missing directories and modify the SOGo app service to create necessary directories for proper functionality.

https://github.com/NethServer/dev/issues/7472

example of custom theme

https://filebin.net/petswvk6cmlxod9p