### PR TITLE
Update to SOGo 5.12.3

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -15,7 +15,7 @@ images=()
 repobase="${REPOBASE:-ghcr.io/nethserver}"
 # Configure the image name
 reponame="sogo"
-sogo_version="5.12.1"
+sogo_version="5.12.3"
 
 # Create a new empty container image
 container=$(buildah from scratch)


### PR DESCRIPTION
This pull request updates the SOGo image version in the `build-images.sh` script to ensure we are building with the latest release.

* Increased the `sogo_version` variable from `5.12.1` to `5.12.3` in `build-images.sh`, which will pull and build the newer SOGo version for container images.

https://github.com/NethServer/dev/issues/7604
