### PR TITLE
Use runagent instead of ssh in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The above command will:
 Some settings are not available in the UI, you need to change them manually, refer to documentation : https://www.sogo.nu/files/docs/SOGoInstallationGuide.html
 
 ```
-ssh sogo1@::1
-vim .config/state/environment
+runagent -m sogo1
+vim environment
 ```
 modify the settings, then restart sogo : `systemctl restart --user sogo`
 


### PR DESCRIPTION
Replaced ssh command with runagent to not require a password.

See [Community forum](https://community.nethserver.org/t/tweaks-inside-sogo/26817?u=mrmarkuz).