### PR TITLE
Update Sogo version to debian-trixie

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -15,7 +15,7 @@ images=()
 repobase="${REPOBASE:-ghcr.io/nethserver}"
 # Configure the image name
 reponame="sogo"
-sogo_version="5.12.4"
+sogo_version="debian-trixie"
 
 # Create a new empty container image
 container=$(buildah from scratch)

--- a/build-images.sh
+++ b/build-images.sh
@@ -15,7 +15,7 @@ images=()
 repobase="${REPOBASE:-ghcr.io/nethserver}"
 # Configure the image name
 reponame="sogo"
-sogo_version="debian-trixie"
+sogo_version="5.12.7"
 
 # Create a new empty container image
 container=$(buildah from scratch)

--- a/imageroot/systemd/user/sogo-app.service
+++ b/imageroot/systemd/user/sogo-app.service
@@ -29,7 +29,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/sogo-app.pid \
     --volume ./config/sogo.conf:/etc/sogo/sogo.conf:Z \
     --volume ./config/cron-sogo:/etc/cron.d/cron-sogo:Z \
     --volume ./config/sieve.creds:/etc/sogo/sieve.creds:Z \
-    --volume ./config/SOGo.conf:/etc/httpd/conf/extra/SOGo.conf:Z \
+    --volume ./config/SOGo.conf:/etc/apache2/conf-available/SOGo.conf:Z \
     --volume ./backups:/etc/sogo/backups:Z \
     ${SOGO_SERVER_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/sogo-app.ctr-id -t 10

--- a/imageroot/templates/SOGo.conf
+++ b/imageroot/templates/SOGo.conf
@@ -1,9 +1,9 @@
 Alias /SOGo.woa/WebServerResources/ \
-      /usr/lib/GNUstep/SOGo/WebServerResources/
+      /usr/local/lib/GNUstep/SOGo/WebServerResources/
 Alias /SOGo/WebServerResources/ \
-      /usr/lib/GNUstep/SOGo/WebServerResources/
+      /usr/local/lib/GNUstep/SOGo/WebServerResources/
 
-<Directory /usr/lib/GNUstep/SOGo/>
+<Directory /usr/local/lib/GNUstep/SOGo/>
     AllowOverride None
 
     <IfVersion < 2.4>


### PR DESCRIPTION
This pull request updates the SOGo container image to use the `debian-trixie` version and adjusts configuration paths to match changes in the underlying operating system and web server. The most important changes are grouped below:

**Image and Version Updates:**

* Updated the `sogo_version` in `build-images.sh` to use `debian-trixie` instead of the previous version `5.12.4`, aligning the container with the new Debian release.

**Configuration Path Adjustments:**

* Changed the Apache configuration volume mount in `sogo-app.service` to point to `/etc/apache2/conf-available/SOGo.conf` instead of the old `/etc/httpd/conf/extra/SOGo.conf`, reflecting the switch to Debian's Apache layout.
* Updated paths in `SOGo.conf` to use `/usr/local/lib/GNUstep/SOGo/WebServerResources/` and `/usr/local/lib/GNUstep/SOGo/` instead of `/usr/lib/GNUstep/SOGo/`, ensuring compatibility with the new file locations.

https://github.com/NethServer/dev/issues/7962