### PR TITLE
feat: add renovate regex manager for sogo_version

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -15,6 +15,7 @@ images=()
 repobase="${REPOBASE:-ghcr.io/nethserver}"
 # Configure the image name
 reponame="sogo"
+# To update: visit https://github.com/Alinto/sogo/tags
 sogo_version="5.12.7"
 
 # Create a new empty container image

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>NethServer/.github:ns8-automerge"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^build-images\\.sh$"],
+      "matchStrings": [
+        "# To update: visit https://github\\.com/Alinto/sogo/tags\\nsogo_version=\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "Alinto/sogo",
+      "packageNameTemplate": "Alinto/sogo",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^SOGo-(?<version>.+)$",
+      "versioningTemplate": "semver",
+      "autoReplaceStringTemplate": "# To update: visit https://github.com/Alinto/sogo/tags\nsogo_version=\"{{{newValue}}}\""
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Add a comment anchor `# To update: visit https://github.com/Alinto/sogo/tags` in `build-images.sh` before `sogo_version`
- Add a `regexManagers` entry in `renovate.json` to track `sogo_version` upgrades from the `Alinto/sogo` GitHub tags (same pattern as sogo-server)