### PR TITLE
fix: use correct SOGo binary paths in cron template

### DIFF
--- a/imageroot/templates/cron.conf
+++ b/imageroot/templates/cron.conf
@@ -2,17 +2,17 @@
 
 # Vacation messages expiration
 # The credentials file should contain the sieve admin credentials (username:passwd)
-0 0 * * *      sogo	/usr/sbin/sogo-tool update-autoreply -p /etc/sogo/sieve.creds
+0 0 * * *      sogo	/usr/local/sbin/sogo-tool update-autoreply -p /etc/sogo/sieve.creds
 
 # Session cleanup - runs every minute
 #   - Ajust the nbMinutes parameter to suit your needs
 # Example: Sessions without activity since 60 minutes will be dropped:
-1 * * * *      sogo	/usr/sbin/sogo-tool expire-sessions {{sessionduration}}
+1 * * * *      sogo	/usr/local/sbin/sogo-tool expire-sessions {{sessionduration}}
 
 # Email alarms - runs every minutes
 # If you need to use SMTP AUTH for outgoing mails, specify credentials to use
 # with '-p /path/to/credentialsFile' (same format as the sieve credentials)
-* * * * *      sogo	/usr/sbin/sogo-ealarms-notify > /dev/null 2>&1
+* * * * *      sogo	/usr/local/sbin/sogo-ealarms-notify > /dev/null 2>&1
 
 # Daily backups
 #   - writes to /etc/sogo/backups/ by default


### PR DESCRIPTION
## Problem

SOGo binaries are installed under `/usr/local/sbin/` in the container (built from [sogo-server](https://github.com/NethServer/sogo-server)), but the `cron.conf` template was referencing `/usr/sbin/` — which does not exist.

As a result, the following cron jobs were **silently failing** with "command not found":

| Job | Wrong path used | Correct path |
|-----|----------------|--------------|
| Vacation auto-reply | `/usr/sbin/sogo-tool update-autoreply` | `/usr/local/sbin/sogo-tool` |
| Session expiry | `/usr/sbin/sogo-tool expire-sessions` | `/usr/local/sbin/sogo-tool` |
| Email alarms | `/usr/sbin/sogo-ealarms-notify` | `/usr/local/sbin/sogo-ealarms-notify` |

## Fix

Replace `/usr/sbin/` with `/usr/local/sbin/` for all three SOGo cron binaries in `imageroot/templates/cron.conf`.

No changes are needed in `sogo-server` — its built-in `/etc/cron.d/sogo` already uses the correct paths.