### PR TITLE
fix: set retry=0 on ActiveSync ProxyPass to avoid stale backend errors

### DIFF
--- a/imageroot/templates/SOGo.conf
+++ b/imageroot/templates/SOGo.conf
@@ -79,7 +79,7 @@ RedirectMatch ^/$ https://{{domain}}/SOGo
 #
 ProxyPass /Microsoft-Server-ActiveSync \
  http://127.0.0.1:20000/SOGo/Microsoft-Server-ActiveSync \
- retry=60 connectiontimeout=5 timeout=3600
+ retry=0 connectiontimeout=5 timeout=3600
 {% endif %}
 
 ProxyPass /SOGo http://127.0.0.1:20000/SOGo retry=0 nocanon


### PR DESCRIPTION
## Problem

With `retry=60` (from the original SOGo documentation), `mod_proxy` marks the backend as **unavailable for 60 seconds** after any connection failure to port 20000.

During this window, without a balancer configured, Apache does not return 503 — it falls through to file-based handlers, finds no file at `/Microsoft-Server-ActiveSync`, and returns **404**.

This causes **random ActiveSync failures** after any sogod worker restart or memory recycle (`SxVMemLimit`), affecting only users who reconnect during the 60s penalty window — which explains why it's random and user-dependent.

```apache
# Before (broken)
ProxyPass /Microsoft-Server-ActiveSync \
 http://127.0.0.1:20000/SOGo/Microsoft-Server-ActiveSync \
 retry=60 connectiontimeout=5 timeout=3600

# After (fixed)
ProxyPass /Microsoft-Server-ActiveSync \
 http://127.0.0.1:20000/SOGo/Microsoft-Server-ActiveSync \
 retry=0 connectiontimeout=5 timeout=3600
```

## Fix

Set `retry=0` — same value already used on the `/SOGo` ProxyPass — so Apache retries the backend immediately on the next request instead of blacklisting it for 60 seconds.

## Related

- sogo-server PR: NethServer/sogo-server#20 (disables `mod_reqtimeout` which causes a separate class of random 404s)
- PR #84 (fixes cron binary paths `/usr/sbin` → `/usr/local/sbin`)