### PR TITLE
Change publish-branch workflow reference to sdl-extra-cache

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   publish-images:
     if: github.run_number > 1
-    uses: NethServer/ns8-github-actions/.github/workflows/publish-branch.yml@v1
+    uses: NethServer/ns8-github-actions/.github/workflows/publish-branch.yml@sdl-extra-cache
   module:
     needs: publish-images
     uses: NethServer/ns8-github-actions/.github/workflows/module-info.yml@v1


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration by changing the referenced branch of a reusable workflow in `.github/workflows/publish-images.yml`. The workflow now uses the `sdl-extra-cache` branch instead of `v1` for the `publish-branch.yml` workflow.